### PR TITLE
PAYARA-3691 Set version to 2.4.3.payara-p2 and use metro 2.3.2-payara-p2

### DIFF
--- a/_security-extras/keyidspi-ibm-impl/pom.xml
+++ b/_security-extras/keyidspi-ibm-impl/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>wssx-impl</artifactId>
-            <version>2.4.3.payara-p1</version>
+            <version>2.4.3.payara-p2</version>
         </dependency>
     </dependencies>
 

--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom</artifactId>
         <relativePath>../bom/pom.xml</relativePath>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>

--- a/wsit/boms/bom-gf/pom.xml
+++ b/wsit/boms/bom-gf/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom</artifactId>
         <relativePath>../bom/pom.xml</relativePath>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>

--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>metro-bom</artifactId>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Dependency POM</name>
-    <version>2.4.3.payara-p1</version>
+    <version>2.4.3.payara-p2</version>
     <description>Metro Web Services Stack Dependency POM</description>
 
     <url>http://javaee.github.io/metro</url>
@@ -56,7 +56,7 @@
     </developers>
 
     <properties>
-        <jaxws.ri.version>2.3.2.payara-p1</jaxws.ri.version>
+        <jaxws.ri.version>2.3.2.payara-p2</jaxws.ri.version>
         <jaxws.maven.plugin.version>2.3.2</jaxws.maven.plugin.version>
     </properties>
 

--- a/wsit/bundles/metro-standalone/pom.xml
+++ b/wsit/bundles/metro-standalone/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-standalone</artifactId>

--- a/wsit/bundles/pom.xml
+++ b/wsit/bundles/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>bundles</artifactId>

--- a/wsit/bundles/webservices-api-osgi/pom.xml
+++ b/wsit/bundles/webservices-api-osgi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-api-osgi</artifactId>

--- a/wsit/bundles/webservices-api/pom.xml
+++ b/wsit/bundles/webservices-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-api</artifactId>

--- a/wsit/bundles/webservices-extra-api/pom.xml
+++ b/wsit/bundles/webservices-extra-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-extra-api</artifactId>

--- a/wsit/bundles/webservices-extra-jdk-packages/pom.xml
+++ b/wsit/bundles/webservices-extra-jdk-packages/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-extra-jdk-packages</artifactId>

--- a/wsit/bundles/webservices-extra/pom.xml
+++ b/wsit/bundles/webservices-extra/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-extra</artifactId>

--- a/wsit/bundles/webservices-osgi-aix/pom.xml
+++ b/wsit/bundles/webservices-osgi-aix/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-osgi-aix</artifactId>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-osgi</artifactId>

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-rt</artifactId>
@@ -439,10 +439,10 @@
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
         </dependency>
-        <dependency>
+     <!--    <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>keyidspi-ibm-impl</artifactId>
-        </dependency>
+        </dependency> -->
         <dependency>
             <groupId>com.sun.xml.registry</groupId>
             <artifactId>jaxr-impl</artifactId>

--- a/wsit/bundles/webservices-tools/pom.xml
+++ b/wsit/bundles/webservices-tools/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>webservices-tools</artifactId>

--- a/wsit/bundles/wsit-api/pom.xml
+++ b/wsit/bundles/wsit-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsit-api</artifactId>

--- a/wsit/bundles/wsit-impl/pom.xml
+++ b/wsit/bundles/wsit-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsit-impl</artifactId>

--- a/wsit/docs/getting-started/pom.xml
+++ b/wsit/docs/getting-started/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>getting-started</artifactId>

--- a/wsit/docs/guide/pom.xml
+++ b/wsit/docs/guide/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>guide</artifactId>

--- a/wsit/docs/pom.xml
+++ b/wsit/docs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>metro-project</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>docs</artifactId>

--- a/wsit/metro-cm/metro-cm-api/pom.xml
+++ b/wsit/metro-cm/metro-cm-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-cm-api</artifactId>

--- a/wsit/metro-cm/metro-cm-impl/pom.xml
+++ b/wsit/metro-cm/metro-cm-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-cm-impl</artifactId>

--- a/wsit/metro-cm/pom.xml
+++ b/wsit/metro-cm/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-cm-project</artifactId>

--- a/wsit/metro-commons/pom.xml
+++ b/wsit/metro-commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-commons</artifactId>

--- a/wsit/metro-config/metro-config-api/pom.xml
+++ b/wsit/metro-config/metro-config-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-config-api</artifactId>

--- a/wsit/metro-config/metro-config-impl/pom.xml
+++ b/wsit/metro-config/metro-config-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-config-impl</artifactId>

--- a/wsit/metro-config/pom.xml
+++ b/wsit/metro-config/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-config</artifactId>

--- a/wsit/metro-runtime/metro-runtime-api/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-runtime-api</artifactId>

--- a/wsit/metro-runtime/metro-runtime-impl/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-runtime-impl</artifactId>

--- a/wsit/metro-runtime/pom.xml
+++ b/wsit/metro-runtime/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>metro-runtime</artifactId>

--- a/wsit/pom.xml
+++ b/wsit/pom.xml
@@ -20,12 +20,12 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom-ext</artifactId>
         <relativePath>boms/bom-ext/pom.xml</relativePath>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>
     <artifactId>metro-project</artifactId>
-    <version>2.4.3.payara-p1</version>
+    <version>2.4.3.payara-p2</version>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Project</name>
 

--- a/wsit/soaptcp/pom.xml
+++ b/wsit/soaptcp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>soaptcp</artifactId>

--- a/wsit/soaptcp/soaptcp-api/pom.xml
+++ b/wsit/soaptcp/soaptcp-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>soaptcp-api</artifactId>

--- a/wsit/soaptcp/soaptcp-impl/pom.xml
+++ b/wsit/soaptcp/soaptcp-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>soaptcp-impl</artifactId>

--- a/wsit/tests/coverage/pom.xml
+++ b/wsit/tests/coverage/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/wsit/tests/e2e/pom.xml
+++ b/wsit/tests/e2e/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/osgi-test/pom.xml
+++ b/wsit/tests/osgi-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/pom.xml
+++ b/wsit/tests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsit-tests</artifactId>

--- a/wsit/ws-mex/pom.xml
+++ b/wsit/ws-mex/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>ws-mex</artifactId>

--- a/wsit/ws-rx/pom.xml
+++ b/wsit/ws-rx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsrx-project</artifactId>

--- a/wsit/ws-rx/wsmc-api/pom.xml
+++ b/wsit/ws-rx/wsmc-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
         <!--relativePath>../../pom.xml</relativePath-->
     </parent>
 

--- a/wsit/ws-rx/wsmc-impl/pom.xml
+++ b/wsit/ws-rx/wsmc-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsmc-impl</artifactId>

--- a/wsit/ws-rx/wsrm-api/pom.xml
+++ b/wsit/ws-rx/wsrm-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
         <!--relativePath>../../pom.xml</relativePath-->
     </parent>
 

--- a/wsit/ws-rx/wsrm-impl/pom.xml
+++ b/wsit/ws-rx/wsrm-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsrm-impl</artifactId>

--- a/wsit/ws-rx/wsrx-commons/pom.xml
+++ b/wsit/ws-rx/wsrx-commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsrx-commons</artifactId>

--- a/wsit/ws-rx/wsrx-testing/pom.xml
+++ b/wsit/ws-rx/wsrx-testing/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wsrx-testing</artifactId>

--- a/wsit/ws-sx/pom.xml
+++ b/wsit/ws-sx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wssx-project</artifactId>

--- a/wsit/ws-sx/wssx-api/pom.xml
+++ b/wsit/ws-sx/wssx-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wssx-api</artifactId>

--- a/wsit/ws-sx/wssx-impl/pom.xml
+++ b/wsit/ws-sx/wssx-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wssx-impl</artifactId>

--- a/wsit/ws-tx/pom.xml
+++ b/wsit/ws-tx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wstx-project</artifactId>

--- a/wsit/ws-tx/wstx-api/pom.xml
+++ b/wsit/ws-tx/wstx-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wstx-api</artifactId>

--- a/wsit/ws-tx/wstx-core/pom.xml
+++ b/wsit/ws-tx/wstx-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wstx-core</artifactId>

--- a/wsit/ws-tx/wstx-impl/pom.xml
+++ b/wsit/ws-tx/wstx-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wstx-impl</artifactId>

--- a/wsit/ws-tx/wstx-services/pom.xml
+++ b/wsit/ws-tx/wstx-services/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>wstx-services</artifactId>

--- a/wsit/xmlfilter/pom.xml
+++ b/wsit/xmlfilter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.3.payara-p1</version>
+        <version>2.4.3.payara-p2</version>
     </parent>
 
     <artifactId>xmlfilter</artifactId>


### PR DESCRIPTION
Updating to 2.4.3.payara-p2 and using RI 2.3.2-payara-p2

Depends on https://github.com/payara/patched-src-metro-jax-ws/pull/3

cc @fturizo 