### PR TITLE
FISH-5811 Upgrade Santuario to version 2.2.3

### DIFF
--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -32,8 +32,10 @@
         <connector-api.version>1.7.3</connector-api.version>
         <transaction-api.version>1.3.2</transaction-api.version>
         <jaxws.home.uri>http://javaee.github.io/metro-jax-ws</jaxws.home.uri>
-        <santuario.version>1.5.8</santuario.version>
+        <santuario.version>2.2.3</santuario.version>
         <commons-logging.version>1.1.2</commons-logging.version>
+        <commons-codec.version>1.13</commons-codec.version>
+        <slf4j-api.version>1.7.30</slf4j-api.version>
         <xmlrpc-api.version>1.1.3</xmlrpc-api.version>
         <xmlrpc-impl.version>1.1.5</xmlrpc-impl.version>
         <resolver.version>20050927</resolver.version>
@@ -62,6 +64,23 @@
                 <groupId>jakarta.transaction</groupId>
                 <artifactId>jakarta.transaction-api</artifactId>
                 <version>${transaction-api.version}</version>
+            </dependency>
+
+            <!-- Santuario -->
+            <dependency>
+                <groupId>org.apache.santuario</groupId>
+                <artifactId>xmlsec</artifactId>
+                <version>${santuario.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j-api.version}</version>
             </dependency>
 
         </dependencies>

--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2019 Payara Foundation and/or its affiliates.
+    Copyright (c) 2019-2021 Payara Foundation and/or its affiliates.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/metro-standalone/pom.xml
+++ b/wsit/bundles/metro-standalone/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Payara Foundation and/or its affiliates.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/metro-standalone/pom.xml
+++ b/wsit/bundles/metro-standalone/pom.xml
@@ -391,8 +391,12 @@
             <artifactId>xmlsec</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
         </dependency>
     </dependencies>
 

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -274,6 +274,7 @@
                             org.apache.log;resolution:=optional,
                             org.apache.log4j;resolution:=optional,
                             org.apache.avalon.framework.logger;resolution:=optional,
+                            org.slf4j.impl.*;resolution:=optional,
                             *
                         </Import-Package>
                         <Private-Package>
@@ -281,8 +282,10 @@
                             com.sun.xml.xwss.*;version=${metro.osgiVersion},
                             com.sun.xml.util.*;version=${metro.osgiVersion};include="XMLCipherAdapter",
                             javanet.staxutils.*,
-                            org.apache.commons.logging,
-                            org.apache.commons.logging.impl,
+                            org.apache.commons.codec,
+                            org.apache.commons.codec.*,
+                            org.slf4j,
+                            org.slf4j.*
                         </Private-Package>
                         <DynamicImport-Package>
                             org.glassfish.flashlight.provider,
@@ -416,8 +419,12 @@
             <artifactId>xmlsec</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
         </dependency>
     </dependencies>
     <properties>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2019 Payara Foundation and/or its affiliates.
+    Copyright (c) 2019-2021 Payara Foundation and/or its affiliates.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Payara Foundation and/or its affiliates.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -217,6 +217,13 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>slf4j-api</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -282,8 +289,11 @@
                                     <include>com.sun.xml.registry:jaxr-impl</include>
                                     <include>com.sun.xml.rpc:jaxrpc-impl</include>
                                     <include>com.sun.xml.rpc:jaxrpc-spi</include>
+                                    <!-- santuario -->
                                     <include>org.apache.santuario:xmlsec</include>
-                                    <include>commons-logging:commons-logging</include>
+                                    <include>org.slf4j:slf4j-api</include>
+                                    <include>commons-codec:commons-codec</include>
+
                                     <include>com.sun.xml.stream.buffer:streambuffer</include>
                                     <include>com.sun.xml.ws:jaxws-rt</include>
                                     <include>com.sun.xml.ws:policy</include>
@@ -310,13 +320,6 @@
                                     <artifact>com.sun.xml.rpc:jaxrpc-impl</artifact>
                                     <excludes>
                                         <exclude>META-INF/jaxrpc/ToolPlugin.xml</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.apache.santuario:xmlsec</artifact>
-                                    <excludes>
-                                        <!-- included in JDK -->
-                                        <exclude>javax/xml/crypto/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
@@ -357,12 +360,6 @@
                             <version>2.5.0</version>
                         </dependency>
                     </additionalDependencies>
-                    <sourceFileExcludes>
-                        <sourceFileExclude>META-INF/**</sourceFileExclude>
-                        <sourceFileExclude>**/msv/**</sourceFileExclude>
-                        <sourceFileExclude>**/osgi/**</sourceFileExclude>
-                        <sourceFileExclude>org/apache/**</sourceFileExclude>
-                    </sourceFileExcludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
+import org.apache.xml.security.utils.resolver.ResourceResolverContext;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -36,18 +37,15 @@ import org.apache.xml.security.utils.XMLUtils;
 import org.apache.xml.security.utils.resolver.ResourceResolverException;
 import org.apache.xml.security.utils.resolver.ResourceResolverSpi;
 import com.sun.xml.wss.WSITXMLFactory;
-import com.sun.xml.wss.XWSSecurityException;
 import com.sun.xml.wss.impl.MessageConstants;
 import com.sun.xml.wss.impl.dsig.NamespaceContextImpl;
 import com.sun.xml.wss.logging.LogDomainConstants;
 import com.sun.xml.wss.logging.LogStringsMessages;
-import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
-import javax.xml.xpath.XPathFactoryConfigurationException;
 
 
 /**
@@ -116,14 +114,14 @@ public class ResolverId extends ResourceResolverSpi {
             log.log(Level.SEVERE,
                     LogStringsMessages.WSS_0603_XPATHAPI_TRANSFORMER_EXCEPTION(e.getMessage()),
                     e.getMessage());
-            throw new ResourceResolverException("empty", e, uri, BaseURI);
+             throw new ResourceResolverException(e, uri.getValue(), BaseURI, "empty");
          }
       }
 
       if (selectedElem == null) {
           log.log(Level.SEVERE,
                   LogStringsMessages.WSS_0604_CANNOT_FIND_ELEMENT());
-          throw new ResourceResolverException("empty", uri, BaseURI);
+          throw new ResourceResolverException("empty", uri.getValue(), BaseURI);
       }
       Set resultSet = dereferenceSameDocumentURI(selectedElem);
       XMLSignatureInput result = new XMLSignatureInput(resultSet);
@@ -357,5 +355,13 @@ public class ResolverId extends ResourceResolverSpi {
 		nodeSet.add(node);
 	}
    }
+
+    public XMLSignatureInput engineResolveURI(ResourceResolverContext context) throws ResourceResolverException {
+        return null;
+    }
+
+    public boolean engineCanResolveURI(ResourceResolverContext context) {
+        return false;
+    }
 }
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
@@ -357,12 +357,14 @@ public class ResolverId extends ResourceResolverSpi {
 	}
    }
 
-    public XMLSignatureInput engineResolveURI(ResourceResolverContext context) throws ResourceResolverException {
-        return null;
+    @Override
+    public XMLSignatureInput engineResolveURI(ResourceResolverContext rrc) throws ResourceResolverException {
+        return engineResolve(rrc.attr, rrc.baseUri);
     }
 
-    public boolean engineCanResolveURI(ResourceResolverContext context) {
-        return false;
+    @Override
+    public boolean engineCanResolveURI(ResourceResolverContext rrc) {
+        return engineCanResolve(rrc.attr, rrc.baseUri);
     }
 }
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
@@ -552,12 +552,14 @@ public class URIResolver extends ResourceResolverSpi {
                                     "Can not resolve reference type",
                                     "Required SOAPMessage instance to resolve reference"};
 
-    public XMLSignatureInput engineResolveURI(ResourceResolverContext resourceResolverContext) throws ResourceResolverException {
-        return null;
+    @Override
+    public XMLSignatureInput engineResolveURI(ResourceResolverContext rrc) throws ResourceResolverException {
+        return engineResolve(rrc.attr, rrc.baseUri);
     }
 
-    public boolean engineCanResolveURI(ResourceResolverContext resourceResolverContext) {
-        return false;
+    @Override
+    public boolean engineCanResolveURI(ResourceResolverContext rrc) {
+        return engineCanResolve(rrc.attr, rrc.baseUri);
     }
 }
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
@@ -14,7 +14,7 @@
 
 package com.sun.xml.wss.impl.transform;
 
-import javax.mail.internet.ContentType;
+import javax.xml.parsers.ParserConfigurationException;
 
 import com.sun.xml.wss.impl.c14n.Canonicalizer;
 import com.sun.xml.wss.impl.c14n.CanonicalizerFactory;
@@ -22,9 +22,16 @@ import com.sun.xml.wss.impl.c14n.MimeHeaderCanonicalizer;
 
 import com.sun.xml.wss.impl.resolver.AttachmentSignatureInput;
 
+import org.apache.xml.security.c14n.CanonicalizationException;
+import org.apache.xml.security.c14n.InvalidCanonicalizerException;
 import org.apache.xml.security.transforms.TransformSpi;
 import org.apache.xml.security.signature.XMLSignatureInput; 
 import org.apache.xml.security.transforms.TransformationException;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.OutputStream;
 
 public class AttachmentCompleteTransform extends TransformSpi {
 
@@ -72,4 +79,9 @@ public class AttachmentCompleteTransform extends TransformSpi {
    public boolean wantsNodeSet ()       { return true; }
    public boolean returnsOctetStream () { return true; }
    public boolean returnsNodeSet ()     { return false; }
+
+    // Required by Santuario 2.2.X
+   protected XMLSignatureInput enginePerformTransform(XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation) throws IOException, CanonicalizationException, InvalidCanonicalizerException, TransformationException, ParserConfigurationException, SAXException {
+       return null;
+   }
 }

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
@@ -15,23 +15,15 @@
 
 package com.sun.xml.wss.impl.transform;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import com.sun.xml.wss.impl.c14n.Canonicalizer;
 import com.sun.xml.wss.impl.c14n.CanonicalizerFactory;
 import com.sun.xml.wss.impl.c14n.MimeHeaderCanonicalizer;
-
 import com.sun.xml.wss.impl.resolver.AttachmentSignatureInput;
-
-import org.apache.xml.security.c14n.CanonicalizationException;
-import org.apache.xml.security.c14n.InvalidCanonicalizerException;
+import org.apache.xml.security.signature.XMLSignatureInput;
 import org.apache.xml.security.transforms.TransformSpi;
-import org.apache.xml.security.signature.XMLSignatureInput; 
 import org.apache.xml.security.transforms.TransformationException;
 import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 public class AttachmentCompleteTransform extends TransformSpi {
@@ -45,8 +37,8 @@ public class AttachmentCompleteTransform extends TransformSpi {
    }
 
    protected XMLSignatureInput enginePerformTransform(
-             XMLSignatureInput input)
-             throws TransformationException {
+           XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation)
+           throws TransformationException {
        try {
             return new XMLSignatureInput(_canonicalize(input));
        } catch (Exception e) {
@@ -80,9 +72,4 @@ public class AttachmentCompleteTransform extends TransformSpi {
    public boolean wantsNodeSet ()       { return true; }
    public boolean returnsOctetStream () { return true; }
    public boolean returnsNodeSet ()     { return false; }
-
-    // Required by Santuario 2.2.X
-   protected XMLSignatureInput enginePerformTransform(XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation) throws IOException, CanonicalizationException, InvalidCanonicalizerException, TransformationException, ParserConfigurationException, SAXException {
-       return null;
-   }
 }

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
@@ -15,22 +15,14 @@
 
 package com.sun.xml.wss.impl.transform;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import com.sun.xml.wss.impl.c14n.Canonicalizer;
 import com.sun.xml.wss.impl.c14n.CanonicalizerFactory;
-
 import com.sun.xml.wss.impl.resolver.AttachmentSignatureInput;
-
-import org.apache.xml.security.c14n.CanonicalizationException;
-import org.apache.xml.security.c14n.InvalidCanonicalizerException;
+import org.apache.xml.security.signature.XMLSignatureInput;
 import org.apache.xml.security.transforms.TransformSpi;
-import org.apache.xml.security.signature.XMLSignatureInput; 
 import org.apache.xml.security.transforms.TransformationException;
 import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 public class AttachmentContentOnlyTransform extends TransformSpi {
@@ -44,8 +36,8 @@ public class AttachmentContentOnlyTransform extends TransformSpi {
    }
 
    protected XMLSignatureInput enginePerformTransform(
-             XMLSignatureInput input)
-             throws TransformationException {
+           XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation)
+           throws TransformationException {
        try {
             return new XMLSignatureInput(_canonicalize(input));
        } catch (Exception e) {
@@ -69,9 +61,4 @@ public class AttachmentContentOnlyTransform extends TransformSpi {
    public boolean wantsNodeSet ()       { return true; }
    public boolean returnsOctetStream () { return true; }
    public boolean returnsNodeSet ()     { return false; }
-
-    // Required by Santuario 2.2.X
-    protected XMLSignatureInput enginePerformTransform(XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation) throws IOException, CanonicalizationException, InvalidCanonicalizerException, TransformationException, ParserConfigurationException, SAXException {
-        return null;
-    }
 }

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
@@ -44,8 +44,8 @@ public class AttachmentContentOnlyTransform extends TransformSpi {
    }
 
    protected XMLSignatureInput enginePerformTransform(
-             XMLSignatureInput input)
-             throws TransformationException {
+           XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation)
+           throws TransformationException {
        try {
             return new XMLSignatureInput(_canonicalize(input));
        } catch (Exception e) {
@@ -69,9 +69,4 @@ public class AttachmentContentOnlyTransform extends TransformSpi {
    public boolean wantsNodeSet ()       { return true; }
    public boolean returnsOctetStream () { return true; }
    public boolean returnsNodeSet ()     { return false; }
-
-    // Required by Santuario 2.2.X
-    protected XMLSignatureInput enginePerformTransform(XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation) throws IOException, CanonicalizationException, InvalidCanonicalizerException, TransformationException, ParserConfigurationException, SAXException {
-        return null;
-    }
 }

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
@@ -14,16 +14,23 @@
 
 package com.sun.xml.wss.impl.transform;
 
-import javax.mail.internet.ContentType;
+import javax.xml.parsers.ParserConfigurationException;
 
 import com.sun.xml.wss.impl.c14n.Canonicalizer;
 import com.sun.xml.wss.impl.c14n.CanonicalizerFactory;
 
 import com.sun.xml.wss.impl.resolver.AttachmentSignatureInput;
 
+import org.apache.xml.security.c14n.CanonicalizationException;
+import org.apache.xml.security.c14n.InvalidCanonicalizerException;
 import org.apache.xml.security.transforms.TransformSpi;
 import org.apache.xml.security.signature.XMLSignatureInput; 
 import org.apache.xml.security.transforms.TransformationException;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.OutputStream;
 
 public class AttachmentContentOnlyTransform extends TransformSpi {
 
@@ -31,7 +38,7 @@ public class AttachmentContentOnlyTransform extends TransformSpi {
           "http://docs.oasis-open.org/wss/2004/XX/" + 
           "oasis-2004XX-wss-swa-profile-1.0#Attachment-Content-Only-Transform";
 
-   protected String engineGetURI() {
+    protected String engineGetURI() {
        return implementedTransformURI;
    }
 
@@ -61,4 +68,9 @@ public class AttachmentContentOnlyTransform extends TransformSpi {
    public boolean wantsNodeSet ()       { return true; }
    public boolean returnsOctetStream () { return true; }
    public boolean returnsNodeSet ()     { return false; }
+
+    // Required by Santuario 2.2.X
+    protected XMLSignatureInput enginePerformTransform(XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation) throws IOException, CanonicalizationException, InvalidCanonicalizerException, TransformationException, ParserConfigurationException, SAXException {
+        return null;
+    }
 }


### PR DESCRIPTION
[CVE-2021-40690 ](https://nvd.nist.gov/vuln/detail/CVE-2021-40690#vulnCurrentDescriptionTitle) identified a security issue with Santuario versions prior to 2.2.3 and 2.1.7. This PR updates our patched repo to 2.2.3 which also can run on JDK14+

This also implements some necessary methods and changes for compilation from changes in Apache Santuario between 1.5.8 and 2.2.3

Tested the server starts and admin console loads Windows 10 JDK 8 and JDK17.

_When approved 2.4.3.payara-p6 will be created containing these changes_