### PR TITLE
FISH-5911 Backport Apache Santuario Fix for CVE-2021-40690

### DIFF
--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -64,7 +64,7 @@
         <grizzly.version>1.9.36</grizzly.version>
         <gmbal.version>3.1.0-b001</gmbal.version>
         <jaxws.home.uri>http://jax-ws.java.net</jaxws.home.uri>
-        <santuario.version>1.5.8</santuario.version>
+        <santuario.version>1.5.8.payara-p1</santuario.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
CVE-2021-40690 identified a security issue with Santuario versions prior to 2.2.3 and 2.1.7. Neither of those two versions compile on JDK 7 so the fix was backported on Santuario 1.5.8 for Payara 4 compatibility.

Tested Metro-Wsit compiles on JDK 7 and Payara 4 starts on JDK 7 and JDK 8.

**Blocker:** https://github.com/payara/patched-src-santuario-xml-security-java/pull/1

1.5.8.payara-p1 will be released to Nexus when the blocking PR is approved.