### PR TITLE
FISH-6080 Upgrade Jakarta XML Binding to 4.0

### DIFF
--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <jaxws.ri.version>3.0.2</jaxws.ri.version>
+        <jaxws.ri.version>3.0.2.payara-p1-SNAPSHOT</jaxws.ri.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Resolves OSGi Issues.

Blocked by https://github.com/payara/patched-src-metro-jax-ws/pull/6