### PR TITLE
FISH-6697 Reapply patches

### DIFF
--- a/_security-extras/keyidspi-ibm-impl/pom.xml
+++ b/_security-extras/keyidspi-ibm-impl/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.glassfish.metro</groupId>
     <artifactId>keyidspi-ibm-impl</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>Key Identifier SPI Implementation for IBM JDK</name>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>wssx-impl</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.8.payara-p1</version>
         </dependency>
     </dependencies>
 

--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -36,7 +36,7 @@
         <xmlrpc-impl.version>1.1.6</xmlrpc-impl.version>
 
         <!-- CQ: #22139 -->
-        <santuario.version>2.1.7</santuario.version>
+        <santuario.version>2.2.3</santuario.version>
         <!-- CQ: #22187 -->
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <!-- CQ: #22186 -->

--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -40,6 +40,7 @@
         <santuario.version>2.2.3</santuario.version>
         <!-- CQ: #22187 -->
         <slf4j-api.version>1.7.30</slf4j-api.version>
+        <slf4j-simple.version>1.7.30</slf4j-simple.version>
         <!-- CQ: #22186 -->
         <commons-codec.version>1.15</commons-codec.version>
 
@@ -153,6 +154,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j-simple.version}</version>
             </dependency>
 
             <dependency>

--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -34,6 +34,7 @@
         <transaction-api.version>1.3.3</transaction-api.version>
         <xmlrpc-api.version>1.1.4</xmlrpc-api.version>
         <xmlrpc-impl.version>1.1.6</xmlrpc-impl.version>
+        <resolver.version>20050927</resolver.version>
 
         <!-- CQ: #22139 -->
         <santuario.version>2.2.3</santuario.version>
@@ -170,17 +171,6 @@
                 <version>${grizzly.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.glassfish.metro</groupId>
-                <artifactId>keyidspi-ibm-impl</artifactId>
-                <version>1.1</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>net.java.dev.stax-utils</groupId>
                 <artifactId>stax-utils</artifactId>

--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom</artifactId>
         <relativePath>../bom/pom.xml</relativePath>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>

--- a/wsit/boms/bom-gf/pom.xml
+++ b/wsit/boms/bom-gf/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom</artifactId>
         <relativePath>../bom/pom.xml</relativePath>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>

--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <jaxws.ri.version>2.3.5</jaxws.ri.version>
+        <jaxws.ri.version>2.3.2.payara-p4</jaxws.ri.version>
     </properties>
 
     <dependencyManagement>

--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>metro-bom</artifactId>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Dependency POM</name>
-    <version>2.4.8.payara-p1-SNAPSHOT</version>
+    <version>2.4.8.payara-p1</version>
     <description>Metro Web Services Stack Dependency POM</description>
 
     <url>http://javaee.github.io/metro</url>

--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <jaxws.ri.version>2.3.2.payara-p4</jaxws.ri.version>
+        <jaxws.ri.version>2.3.5.payara-p1</jaxws.ri.version>
     </properties>
 
     <dependencyManagement>

--- a/wsit/bundles/metro-standalone/pom.xml
+++ b/wsit/bundles/metro-standalone/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/pom.xml
+++ b/wsit/bundles/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-api-osgi/pom.xml
+++ b/wsit/bundles/webservices-api-osgi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-api/pom.xml
+++ b/wsit/bundles/webservices-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-extra-api/pom.xml
+++ b/wsit/bundles/webservices-extra-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-extra-jdk-packages/pom.xml
+++ b/wsit/bundles/webservices-extra-jdk-packages/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-extra/pom.xml
+++ b/wsit/bundles/webservices-extra/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-osgi-aix/pom.xml
+++ b/wsit/bundles/webservices-osgi-aix/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -68,7 +68,7 @@
                         </goals>
                         <configuration>
                             <includeGroupIds>com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer,net.java.dev.stax-utils,
-                                com.sun.xml.registry,com.sun.xml.rpc</includeGroupIds>
+                                com.sun.xml.registry,com.sun.xml.rpc,com.sun.org.apache.xml.internal</includeGroupIds>
                             <excludeArtifactIds>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeArtifactIds>
                             <includeScope>provided</includeScope>
                             <classifier>sources</classifier>
@@ -225,6 +225,7 @@
                                     org.apache.xml.dtm*;resolution:=optional,
                                     org.apache.xml.utils*;resolution:=optional,
                                     org.apache.xpath*;resolution:=optional,
+                                    com.sun.org.apache.xml.internal.*;resolution:=optional,
                                     *
                                 </Import-Package>
                                 <DynamicImport-Package>
@@ -399,14 +400,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- To be removed after end of support for JDK 8 -->
-        <dependency>
-            <groupId>com.sun.org.apache.xml.internal</groupId>
-            <artifactId>resolver</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
@@ -515,6 +508,11 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.org.apache.xml.internal</groupId>
+            <artifactId>resolver</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -80,6 +80,19 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>unpack-meta-inf-entries</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludeTransitive>true</excludeTransitive>
+                            <includes>META-INF/services/*, META-INF/metro-default.xml, META-INF/jaxrpc/*</includes>
+                            <excludes>META-INF/services/com.sun.xml.ws.spi.db.*, META-INF/services/com.sun.tools.*, META-INF/services/javax.xml.bind.*, META-INF/services/javax.xml.stream.*, META-INF/services/javax.mail.*, META-INF/services/org.*</excludes>
+                            <outputDirectory>${dep.sources}</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>unpack-sources-mr</id>
                         <phase>generate-sources</phase>
                         <goals>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -9,6 +9,7 @@
 
     SPDX-License-Identifier: BSD-3-Clause
 
+    Portions Copyright 2022 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -192,6 +193,8 @@
                                 <Export-Package>
                                     org.apache.xml.security.*,
                                     org.apache.jcp.xml.dsig.internal.*,
+                                    com.sun.org.apache.xml.internal.resolver;version=${resolver.version},
+                                    com.sun.org.apache.xml.internal.resolver.*;version=${resolver.version},
                                     !internal.*,
                                     !META-INF.*,
                                     *

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -67,8 +67,15 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeGroupIds>com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer,net.java.dev.stax-utils,
-                                com.sun.xml.registry,com.sun.xml.rpc,com.sun.org.apache.xml.internal</includeGroupIds>
+                            <includeGroupIds>com.sun.xml.messaging.saaj,
+                                com.sun.xml.ws,
+                                org.glassfish.metro,
+                                com.sun.xml.stream.buffer,
+                                net.java.dev.stax-utils,
+                                com.sun.xml.registry,
+                                com.sun.xml.rpc,
+                                com.sun.org.apache.xml.internal
+                            </includeGroupIds>
                             <excludeArtifactIds>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeArtifactIds>
                             <includeScope>provided</includeScope>
                             <classifier>sources</classifier>
@@ -111,13 +118,34 @@
                         <id>unpack-classes</id>
                         <phase>prepare-package</phase>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>unpack</goal>
                         </goals>
                         <configuration>
-                            <includeGroupIds>org.apache.santuario,org.slf4j,commons-codec</includeGroupIds>
-                            <includeScope>provided</includeScope>
-                            <excludeTransitive>true</excludeTransitive>
-                            <excludes>module-info.*,META-INF/versions/**,META-INF/MANIFEST.MF</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.santuario</groupId>
+                                    <artifactId>xmlsec</artifactId>
+                                    <type>jar</type>
+                                    <includes>**/*.*</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>slf4j-api</artifactId>
+                                    <type>jar</type>
+                                    <includes>**/*.*</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>slf4j-simple</artifactId>
+                                    <type>jar</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>commons-codec</groupId>
+                                    <artifactId>commons-codec</artifactId>
+                                    <type>jar</type>
+                                    <includes>**/*.*</includes>
+                                </artifactItem>
+                            </artifactItems>
                             <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                         </configuration>
                     </execution>
@@ -206,8 +234,6 @@
                                 <Export-Package>
                                     org.apache.xml.security.*,
                                     org.apache.jcp.xml.dsig.internal.*,
-                                    com.sun.org.apache.xml.internal.resolver;version=${resolver.version},
-                                    com.sun.org.apache.xml.internal.resolver.*;version=${resolver.version},
                                     !internal.*,
                                     !META-INF.*,
                                     *
@@ -238,7 +264,6 @@
                                     org.apache.xml.dtm*;resolution:=optional,
                                     org.apache.xml.utils*;resolution:=optional,
                                     org.apache.xpath*;resolution:=optional,
-                                    com.sun.org.apache.xml.internal.*;resolution:=optional,
                                     *
                                 </Import-Package>
                                 <DynamicImport-Package>
@@ -413,6 +438,14 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- To be removed after end of support for JDK 8 -->
+        <dependency>
+            <groupId>com.sun.org.apache.xml.internal</groupId>
+            <artifactId>resolver</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
@@ -519,13 +552,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.org.apache.xml.internal</groupId>
-            <artifactId>resolver</artifactId>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -173,6 +173,13 @@
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>slf4j-api</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -293,12 +300,8 @@
                         </dependency>
                     </additionalDependencies>
                     <sourceFileExcludes>
-                        <sourceFileExclude>META-INF/**</sourceFileExclude>
-                        <sourceFileExclude>**/msv/**</sourceFileExclude>
-                        <sourceFileExclude>**/osgi/**</sourceFileExclude>
                         <sourceFileExclude>**/gmbal/**</sourceFileExclude>
                         <sourceFileExclude>**/pfl/**</sourceFileExclude>
-                        <sourceFileExclude>org/apache/**</sourceFileExclude>
                         <!-- temporarily disabled: javadoc/JDK 17 fails on following sources -->
                         <sourceFileExclude>**/xml/registry/**</sourceFileExclude>
                     </sourceFileExcludes>

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -180,6 +180,13 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.org.apache.xml.internal</groupId>
+                                    <artifactId>resolver</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-tools/pom.xml
+++ b/wsit/bundles/webservices-tools/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/wsit-api/pom.xml
+++ b/wsit/bundles/wsit-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/wsit-impl/pom.xml
+++ b/wsit/bundles/wsit-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/docs/getting-started/pom.xml
+++ b/wsit/docs/getting-started/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <artifactId>getting-started</artifactId>

--- a/wsit/docs/guide/pom.xml
+++ b/wsit/docs/guide/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <artifactId>guide</artifactId>

--- a/wsit/docs/pom.xml
+++ b/wsit/docs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>metro-project</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <artifactId>docs</artifactId>

--- a/wsit/metro-cm/metro-cm-api/pom.xml
+++ b/wsit/metro-cm/metro-cm-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-cm/metro-cm-impl/pom.xml
+++ b/wsit/metro-cm/metro-cm-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-cm/pom.xml
+++ b/wsit/metro-cm/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-commons/pom.xml
+++ b/wsit/metro-commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-config/metro-config-api/pom.xml
+++ b/wsit/metro-config/metro-config-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-config/metro-config-impl/pom.xml
+++ b/wsit/metro-config/metro-config-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-config/pom.xml
+++ b/wsit/metro-config/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-runtime/metro-runtime-api/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-runtime/metro-runtime-impl/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-runtime/pom.xml
+++ b/wsit/metro-runtime/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/pom.xml
+++ b/wsit/pom.xml
@@ -20,12 +20,12 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom-ext</artifactId>
         <relativePath>boms/bom-ext/pom.xml</relativePath>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>
     <artifactId>metro-project</artifactId>
-    <version>2.4.8.payara-p1-SNAPSHOT</version>
+    <version>2.4.8.payara-p1</version>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Project</name>
 

--- a/wsit/soaptcp/pom.xml
+++ b/wsit/soaptcp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/soaptcp/soaptcp-api/pom.xml
+++ b/wsit/soaptcp/soaptcp-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/soaptcp/soaptcp-impl/pom.xml
+++ b/wsit/soaptcp/soaptcp-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/coverage/pom.xml
+++ b/wsit/tests/coverage/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/wsit/tests/e2e/pom.xml
+++ b/wsit/tests/e2e/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/osgi-test/pom.xml
+++ b/wsit/tests/osgi-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/pom.xml
+++ b/wsit/tests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
     </parent>
 
     <artifactId>wsit-tests</artifactId>

--- a/wsit/ws-mex/pom.xml
+++ b/wsit/ws-mex/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/pom.xml
+++ b/wsit/ws-rx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsmc-api/pom.xml
+++ b/wsit/ws-rx/wsmc-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsmc-impl/pom.xml
+++ b/wsit/ws-rx/wsmc-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrm-api/pom.xml
+++ b/wsit/ws-rx/wsrm-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrm-impl/pom.xml
+++ b/wsit/ws-rx/wsrm-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrx-commons/pom.xml
+++ b/wsit/ws-rx/wsrx-commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrx-testing/pom.xml
+++ b/wsit/ws-rx/wsrx-testing/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-sx/pom.xml
+++ b/wsit/ws-sx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-sx/wssx-api/pom.xml
+++ b/wsit/ws-sx/wssx-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-sx/wssx-impl/pom.xml
+++ b/wsit/ws-sx/wssx-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
@@ -133,10 +133,10 @@ public class URIResolver extends ResourceResolverSpi {
                   result = _resolveCid(uri, baseURI);
                   break;
           case CLOCATION_REFERENCE:
-                  try { 
+                  try {
                      result = _resolveClocation(uri, baseURI);
                   } catch (URIResolverException ure) {
-                     result = ResourceResolver.getInstance(uri, baseURI, false).resolve(uri, baseURI, false);
+                     result = ResourceResolver.resolve(new ResourceResolverContext(uri, baseURI, false));
                   }
                   break; 
           default:

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentCompleteTransform.java
@@ -25,6 +25,9 @@ import com.sun.xml.wss.impl.resolver.AttachmentSignatureInput;
 import org.apache.xml.security.transforms.TransformSpi;
 import org.apache.xml.security.signature.XMLSignatureInput; 
 import org.apache.xml.security.transforms.TransformationException;
+import org.w3c.dom.Element;
+
+import java.io.OutputStream;
 
 public class AttachmentCompleteTransform extends TransformSpi {
 
@@ -37,8 +40,8 @@ public class AttachmentCompleteTransform extends TransformSpi {
    }
 
    protected XMLSignatureInput enginePerformTransform(
-             XMLSignatureInput input)
-             throws TransformationException {
+           XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation)
+           throws TransformationException {
        try {
             return new XMLSignatureInput(_canonicalize(input));
        } catch (Exception e) {

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/transform/AttachmentContentOnlyTransform.java
@@ -24,6 +24,9 @@ import com.sun.xml.wss.impl.resolver.AttachmentSignatureInput;
 import org.apache.xml.security.transforms.TransformSpi;
 import org.apache.xml.security.signature.XMLSignatureInput; 
 import org.apache.xml.security.transforms.TransformationException;
+import org.w3c.dom.Element;
+
+import java.io.OutputStream;
 
 public class AttachmentContentOnlyTransform extends TransformSpi {
 
@@ -36,8 +39,8 @@ public class AttachmentContentOnlyTransform extends TransformSpi {
    }
 
    protected XMLSignatureInput enginePerformTransform(
-             XMLSignatureInput input)
-             throws TransformationException {
+           XMLSignatureInput input, OutputStream os, Element transformElement, String baseURI, boolean secureValidation)
+           throws TransformationException {
        try {
             return new XMLSignatureInput(_canonicalize(input));
        } catch (Exception e) {

--- a/wsit/ws-tx/pom.xml
+++ b/wsit/ws-tx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-tx/wstx-api/pom.xml
+++ b/wsit/ws-tx/wstx-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-tx/wstx-impl/pom.xml
+++ b/wsit/ws-tx/wstx-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-tx/wstx-services/pom.xml
+++ b/wsit/ws-tx/wstx-services/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/xmlfilter/pom.xml
+++ b/wsit/xmlfilter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p1-SNAPSHOT</version>
+        <version>2.4.8.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Description
Reapplied patches from the previous version and fix the way to unpack `santuario` dependencies in webservice-osgi module

## Blocker
https://github.com/payara/patched-src-metro-jax-ws/pull/7 - metro-jax-ws patches