### PR TITLE
FISH-6479 Exclude slf4j from OSGi

### DIFF
--- a/wsit/bundles/metro-standalone/pom.xml
+++ b/wsit/bundles/metro-standalone/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/pom.xml
+++ b/wsit/bundles/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-api-osgi/pom.xml
+++ b/wsit/bundles/webservices-api-osgi/pom.xml
@@ -10,13 +10,14 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-api/pom.xml
+++ b/wsit/bundles/webservices-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-extra-api/pom.xml
+++ b/wsit/bundles/webservices-extra-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-extra-jdk-packages/pom.xml
+++ b/wsit/bundles/webservices-extra-jdk-packages/pom.xml
@@ -10,13 +10,14 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-extra/pom.xml
+++ b/wsit/bundles/webservices-extra/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-osgi-aix/pom.xml
+++ b/wsit/bundles/webservices-osgi-aix/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -236,6 +236,7 @@
                                     org.apache.jcp.xml.dsig.internal.*,
                                     !internal.*,
                                     !META-INF.*,
+                                    !org.slf4j.*,
                                     *
                                 </Export-Package>
                                 <Import-Package>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -9,7 +9,7 @@
 
     SPDX-License-Identifier: BSD-3-Clause
 
-    Portions Copyright 2022 Payara Foundation and/or its affiliates
+    Portions Copyright 2022-2023 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/webservices-tools/pom.xml
+++ b/wsit/bundles/webservices-tools/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/wsit-api/pom.xml
+++ b/wsit/bundles/wsit-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/bundles/wsit-impl/pom.xml
+++ b/wsit/bundles/wsit-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -17,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/docs/getting-started/pom.xml
+++ b/wsit/docs/getting-started/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -18,7 +19,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
     </parent>
 
     <artifactId>getting-started</artifactId>

--- a/wsit/docs/guide/pom.xml
+++ b/wsit/docs/guide/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
     </parent>
 
     <artifactId>guide</artifactId>

--- a/wsit/docs/pom.xml
+++ b/wsit/docs/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <artifactId>metro-project</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
     </parent>
 
     <artifactId>docs</artifactId>

--- a/wsit/metro-cm/metro-cm-api/pom.xml
+++ b/wsit/metro-cm/metro-cm-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-cm/metro-cm-impl/pom.xml
+++ b/wsit/metro-cm/metro-cm-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-cm/pom.xml
+++ b/wsit/metro-cm/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-commons/pom.xml
+++ b/wsit/metro-commons/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-config/metro-config-api/pom.xml
+++ b/wsit/metro-config/metro-config-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-config/metro-config-impl/pom.xml
+++ b/wsit/metro-config/metro-config-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-config/pom.xml
+++ b/wsit/metro-config/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-runtime/metro-runtime-api/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-runtime/metro-runtime-impl/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/metro-runtime/pom.xml
+++ b/wsit/metro-runtime/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/pom.xml
+++ b/wsit/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -25,7 +26,7 @@
 
     <groupId>org.glassfish.metro</groupId>
     <artifactId>metro-project</artifactId>
-    <version>2.4.8.payara-p2</version>
+    <version>2.4.8.payara-p3</version>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Project</name>
 

--- a/wsit/soaptcp/pom.xml
+++ b/wsit/soaptcp/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/soaptcp/soaptcp-api/pom.xml
+++ b/wsit/soaptcp/soaptcp-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/soaptcp/soaptcp-impl/pom.xml
+++ b/wsit/soaptcp/soaptcp-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/coverage/pom.xml
+++ b/wsit/tests/coverage/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -18,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/wsit/tests/e2e/pom.xml
+++ b/wsit/tests/e2e/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -18,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/osgi-test/pom.xml
+++ b/wsit/tests/osgi-test/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -18,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/pom.xml
+++ b/wsit/tests/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
     </parent>
 
     <artifactId>wsit-tests</artifactId>

--- a/wsit/ws-mex/pom.xml
+++ b/wsit/ws-mex/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/pom.xml
+++ b/wsit/ws-rx/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsmc-api/pom.xml
+++ b/wsit/ws-rx/wsmc-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsmc-impl/pom.xml
+++ b/wsit/ws-rx/wsmc-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrm-api/pom.xml
+++ b/wsit/ws-rx/wsrm-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrm-impl/pom.xml
+++ b/wsit/ws-rx/wsrm-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrx-commons/pom.xml
+++ b/wsit/ws-rx/wsrx-commons/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-rx/wsrx-testing/pom.xml
+++ b/wsit/ws-rx/wsrx-testing/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-sx/pom.xml
+++ b/wsit/ws-sx/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-sx/wssx-api/pom.xml
+++ b/wsit/ws-sx/wssx-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-sx/wssx-impl/pom.xml
+++ b/wsit/ws-sx/wssx-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-tx/pom.xml
+++ b/wsit/ws-tx/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-tx/wstx-api/pom.xml
+++ b/wsit/ws-tx/wstx-api/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-tx/wstx-impl/pom.xml
+++ b/wsit/ws-tx/wstx-impl/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/ws-tx/wstx-services/pom.xml
+++ b/wsit/ws-tx/wstx-services/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -18,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/xmlfilter/pom.xml
+++ b/wsit/xmlfilter/pom.xml
@@ -10,6 +10,7 @@
     SPDX-License-Identifier: BSD-3-Clause
 
 -->
+<!-- Portions Copyright 2023 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.8.payara-p2</version>
+        <version>2.4.8.payara-p3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Metro exported slf4j by mistake, this PR excludes it from OSGi export.

For reviewer: the important change is in wsit/bundles/webservices-osgi/pom.xml