### PR TITLE
FISH-12425: Update distributionManagement

### DIFF
--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -303,12 +303,12 @@
             <id>patched-project-release</id>
             <distributionManagement>
                 <repository>
-                    <id>payara-nexus-artifacts</id>
-                    <url>https://nexus.dev.payara.fish/repository/payara-artifacts/</url>
+                    <id>payara-nexus-enterprise-artifacts</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-enterprise-artifacts-private/</url>
                 </repository>
                 <snapshotRepository>
-                    <id>payara-nexus-snapshots</id>
-                    <url>https://nexus.dev.payara.fish/repository/payara-snapshots/</url>
+                    <id>payara-nexus-enterprise-snapshots</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-enterprise-snapshots-private/</url>
                 </snapshotRepository>
             </distributionManagement>
             <build>


### PR DESCRIPTION
- Part of FISH-12425
  - Updates the `<distributionManagement>` block to point to the Enterprise repository.